### PR TITLE
Fix to label the data from the column names

### DIFF
--- a/day3/textasdata-dictionaries.Rmd
+++ b/day3/textasdata-dictionaries.Rmd
@@ -94,7 +94,7 @@ mfDf <- as.data.frame(mfRelDfm)
 #install.packages("radarchart")
 library(radarchart)
 
-labels <- substr(colnames(mfDf),23,40)
+labels <- colnames(mfDf)[2:12]
 
 scores <- list(
   "Bernie Sanders" = as.numeric(mfDf[1,]),


### PR DESCRIPTION
Output of previous code: 
`[1] "" "" "" "" "" "" "" "" "" "" "" ""`

Output of new code: 
`[1] "HarmVirtue"      "HarmVice"        "FairnessVirtue"  "FairnessVice"    "IngroupVirtue"   "IngroupVice"`
` [7] "AuthorityVirtue" "AuthorityVice"   "PurityVirtue"    "PurityVice"      "MoralityGeneral"`